### PR TITLE
fix : 초기 로딩상태 수정

### DIFF
--- a/ComposeMVISample/app/src/main/java/com/hana/composemvisample/ui/MainState.kt
+++ b/ComposeMVISample/app/src/main/java/com/hana/composemvisample/ui/MainState.kt
@@ -1,12 +1,23 @@
 package com.hana.composemvisample.ui
 
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
 import androidx.paging.PagingData
 import com.hana.composemvisample.data.model.Repo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 data class MainState(
-    val reposPaging: Flow<PagingData<Repo>> = flowOf(PagingData.empty()),
+    val reposPaging: Flow<PagingData<Repo>> = flowOf(
+        PagingData.from(
+            emptyList(),
+            LoadStates(
+                prepend = LoadState.NotLoading(endOfPaginationReached = true),
+                append = LoadState.NotLoading(endOfPaginationReached = true),
+                refresh = LoadState.NotLoading(endOfPaginationReached = true),
+            )
+        )
+    ),
     val loading: Boolean = false,
     val error: String? = null
 )

--- a/ComposeMVISample/app/src/main/java/com/hana/composemvisample/ui/ReposScreen.kt
+++ b/ComposeMVISample/app/src/main/java/com/hana/composemvisample/ui/ReposScreen.kt
@@ -80,9 +80,6 @@ fun SearchScreen(
                         )
                     )
                 }
-                pagingList.loadState.refresh is LoadState.Loading -> {
-                    CircularProgressIndicator()
-                }
             }
 
             LazyColumn {


### PR DESCRIPTION
기존 처럼 초기에 검색을 진행하지 않고도 로딩처리가 가능하게 수정했습니다.

수정 부분은 다음과 같습니다.
초기 MainState부분을 다음과 같이 수정했습니다.
```
// 수정
pagingData.empty() 

public fun <T : Any> empty(): PagingData<T> = PagingData(
    flow = flowOf(
        PageEvent.StaticList(
            data = listOf(),
            sourceLoadStates = null,
            mediatorLoadStates = null,
        )
    ),
    uiReceiver = NOOP_UI_RECEIVER,
    hintReceiver = NOOP_HINT_RECEIVER,
)
```
초기 PagingData.emtpy() 에서 `sourceLoadStates`의 초기화를 진행하지 않으면 `Loading`으로 표시되는 것으로 추정됩니다.

```
// 수정 후
PagingData.from(
    emptyList(),
    LoadStates(
        prepend = LoadState.NotLoading(endOfPaginationReached = true),
        append = LoadState.NotLoading(endOfPaginationReached = true),
        refresh = LoadState.NotLoading(endOfPaginationReached = true),
    )
)
```